### PR TITLE
Bug/29 blank record inserted into database after detection of malfomed json payload

### DIFF
--- a/code/queryHandlers/RESTfulAPI_DefaultQueryHandler.php
+++ b/code/queryHandlers/RESTfulAPI_DefaultQueryHandler.php
@@ -348,7 +348,7 @@ class RESTfulAPI_DefaultQueryHandler implements RESTfulAPI_QueryHandler
       );
     }
 
-    return $this->updateModel($model, $newModel->ID, $request);
+    return $this->updateModel($model, 0, $request);
   }
 
 

--- a/code/queryHandlers/RESTfulAPI_DefaultQueryHandler.php
+++ b/code/queryHandlers/RESTfulAPI_DefaultQueryHandler.php
@@ -348,6 +348,15 @@ class RESTfulAPI_DefaultQueryHandler implements RESTfulAPI_QueryHandler
       );
     }
 
+    // Check for malformed request
+    $payload = $this->deSerializer->deserialize( $request->getBody() );
+    if ( $payload instanceof RESTfulAPI_Error )
+    {
+      return new RESTfulAPI_ERROR(400,
+        "Malformed body."
+      );
+    }
+
     $newModel = Injector::inst()->create($model);
     $newModel->write();
 

--- a/code/queryHandlers/RESTfulAPI_DefaultQueryHandler.php
+++ b/code/queryHandlers/RESTfulAPI_DefaultQueryHandler.php
@@ -348,18 +348,6 @@ class RESTfulAPI_DefaultQueryHandler implements RESTfulAPI_QueryHandler
       );
     }
 
-    // Check for malformed request
-    $payload = $this->deSerializer->deserialize( $request->getBody() );
-    if ( $payload instanceof RESTfulAPI_Error )
-    {
-      return new RESTfulAPI_ERROR(400,
-        "Malformed body."
-      );
-    }
-
-    $newModel = Injector::inst()->create($model);
-    $newModel->write();
-
     return $this->updateModel($model, $newModel->ID, $request);
   }
 
@@ -371,11 +359,11 @@ class RESTfulAPI_DefaultQueryHandler implements RESTfulAPI_QueryHandler
    * @param Integer $id The ID of the model to update
    * @param SS_HTTPRequest the original request
    *
-   * @return DataObject The updated model 
+   * @return DataObject The updated model
    */
   function updateModel($model, $id, $request)
   {
-    $model = DataObject::get_by_id($model, $id);
+    $model = ( $id == 0 ? Injector::inst()->create($model) : DataObject::get_by_id($model, $id) );
     if ( !$model )
     {
       return new RESTfulAPI_Error(404,


### PR DESCRIPTION
Probably not best of principles to fix this bug, but works reliably.

Returns a 400 if a malformed json payload is received on create method. We could compare the return of updateModel with RESTfulAPI_Error and delete $newModel if it matches and avoid a double de serialization of the request body, but that would also advance the database ID for subsequent insertions.