### PR TITLE
Make skipped query parameters configurable

### DIFF
--- a/code/queryHandlers/RESTfulAPI_DefaultQueryHandler.php
+++ b/code/queryHandlers/RESTfulAPI_DefaultQueryHandler.php
@@ -45,6 +45,15 @@ class RESTfulAPI_DefaultQueryHandler implements RESTfulAPI_QueryHandler
 
 
   /**
+   * Query vars to skip (uppercased)
+   * 
+   * @var array
+   * @config
+   */
+  private static $skipedQueryParameters = array('URL', 'FLUSH', 'FLUSHTOKEN');
+
+
+  /**
    * Set a maximum numbers of records returned by the API.
    * Only affectects "GET All". Useful to avoid returning millions of records at once.
    * 
@@ -193,9 +202,8 @@ class RESTfulAPI_DefaultQueryHandler implements RESTfulAPI_QueryHandler
 
     foreach ($params as $key__mod => $value)
     {
-      //if ( strtoupper($key__mod) === 'URL' ) continue;
-      // skip ul, flush, flushtoken
-      if ( in_array(strtoupper($key__mod), array('URL', 'FLUSH', 'FLUSHTOKEN')) ) continue;
+      // skip url, flush, flushtoken
+      if ( in_array(strtoupper($key__mod), Config::inst()->get('RESTfulAPI_DefaultQueryHandler', 'skipedQueryParameters')) ) continue;
 
       $param = array();
 

--- a/doc/DefaultQueryHandler.md
+++ b/doc/DefaultQueryHandler.md
@@ -6,6 +6,7 @@ Config | Type | Info | Default
 --- | :---: | --- | ---
 `dependencies` | `array` | key => value pair specifying which deserializer to use | 'deSerializer' => '%$RESTfulAPI_BasicDeSerializer'
 `searchFilterModifiersSeparator` | `string` | Separator used in HTTP params between the column name and the search filter modifier (e.g. ?name__StartsWith=Henry will find models with the column name that starts with 'Henry'. ORM equivalent *->filter(array('name::StartsWith' => 'Henry'))* ) | '__'
+`skipedQueryParameters` | `array` | Uppercased query params that would not parsed as column names (uppercased) | 'URL', 'FLUSH', 'FLUSHTOKEN'
 `max_records_limit` | `int` | specify the maximum number of records to return by default (avoid the api returning millions...) | 100
 
 


### PR DESCRIPTION
This is useful when you need to add some special parameter e.g. 'l=en_US' for Fluent module.