### PR TITLE
Improve token stability by making the API token a "unique" index.

### DIFF
--- a/code/authenticator/RESTfulAPI_TokenAuthExtension.php
+++ b/code/authenticator/RESTfulAPI_TokenAuthExtension.php
@@ -19,6 +19,15 @@ class RESTfulAPI_TokenAuthExtension extends DataExtension
     'ApiTokenExpire' => 'Int'
 	);
 
+  // Add a unique index to the API token.
+  // Should increase lookup performance and prevent duplicate tokens.
+  private static $indexes = array(
+    'ApiToken' => array(
+      'type' => 'unique',
+      'value' => '"ApiToken"'
+    )
+  );
+
 	function updateCMSFields(FieldList $fields)
 	{
 	  $fields->removeByName('ApiToken');

--- a/code/authenticator/RESTfulAPI_TokenAuthenticator.php
+++ b/code/authenticator/RESTfulAPI_TokenAuthenticator.php
@@ -152,14 +152,7 @@ class RESTfulAPI_TokenAuthenticator implements RESTfulAPI_Authenticator
         ));
         if ( $member )
         {
-          $tokenData = $this->generateToken();
-
-          $tokenDBColumn  = $this->tokenConfig['DBColumn'];
-          $expireDBColumn = $this->tokenConfig['expireDBColumn'];
-
-          $member->{$tokenDBColumn}  = $tokenData['token'];
-          $member->{$expireDBColumn} = $tokenData['expire'];
-          $member->write();
+          $tokenData = $this->updateToken($member);
           $member->login();
         }
       }
@@ -203,16 +196,7 @@ class RESTfulAPI_TokenAuthenticator implements RESTfulAPI_Authenticator
 
       if ( $this->tokenConfig['owner'] === 'Member' )
       {
-        //generate expired token
-        $tokenData = $this->generateToken( true );
-
-        //write
-        $tokenDBColumn  = $this->tokenConfig['DBColumn'];
-        $expireDBColumn = $this->tokenConfig['expireDBColumn'];
-
-        $member->{$tokenDBColumn}  = $tokenData['token'];
-        $member->{$expireDBColumn} = $tokenData['expire'];
-        $member->write();
+        $this->updateToken($member, true);
       }      
     }
   }
@@ -291,16 +275,7 @@ class RESTfulAPI_TokenAuthenticator implements RESTfulAPI_Authenticator
 
       if ( $owner )
       {
-        //generate token
-        $tokenData = $this->generateToken( $expired );
-
-        //write
-        $tokenDBColumn  = $this->tokenConfig['DBColumn'];
-        $expireDBColumn = $this->tokenConfig['expireDBColumn'];
-
-        $owner->{$tokenDBColumn}  = $tokenData['token'];
-        $owner->{$expireDBColumn} = $tokenData['expire'];
-        $owner->write();
+        $this->updateToken($owner, $expired);
       }
       else{
         user_error("API Token owner '$ownerClass' not found with ID = $id", E_USER_WARNING);
@@ -342,6 +317,40 @@ class RESTfulAPI_TokenAuthenticator implements RESTfulAPI_Authenticator
       'token' => substr($token, 7),
       'expire' => $expire
     ); 
+  }
+
+  /**
+   * Update the token of a token owner
+   * @param $owner          The token owner instance to update
+   * @param bool $expired   Set to true to generate an outdated token
+   * @return array|null     Token data array('token' => HASH, 'expire' => EXPIRY_DATE)
+   */
+  private function updateToken($owner, $expired = false)
+  {
+    $ownerId = null;
+    $tokenData = null;
+
+    // DB field names
+    $tokenDBColumn  = $this->tokenConfig['DBColumn'];
+    $expireDBColumn = $this->tokenConfig['expireDBColumn'];
+
+    do {
+      try {
+        //generate token
+        $tokenData = $this->generateToken( $expired );
+
+        // ensure we never regenerate the same token!
+        if($owner->{$tokenDBColumn} != $tokenData['token']){
+          $owner->{$tokenDBColumn}  = $tokenData['token'];
+          $owner->{$expireDBColumn} = $tokenData['expire'];
+          $ownerId = $owner->write();
+        }
+      } catch(Exception $e){
+        $ownerId = null;
+      }
+    } while(!$ownerId);
+
+    return $tokenData;
   }
 
 

--- a/tests/authenticator/RESTfulAPI_TokenAuthenticator_Test.php
+++ b/tests/authenticator/RESTfulAPI_TokenAuthenticator_Test.php
@@ -209,4 +209,35 @@ class RESTfulAPI_TokenAuthenticator_Test extends RESTfulAPI_Tester
       "TokenAuth authentication failure should return a RESTfulAPI_Error"
     );
   }
+
+  /**
+   * Test edge case of a member with the same API token
+   */
+  public function testTokenUniqueness()
+  {
+    $writtenCount = 0;
+    // attempt to write two members with the same API token
+    for($i = 0; $i < 2; $i++){
+      try {
+        $memberID = Member::create(array(
+          'Email' => 'TestMember' . $i,
+          'Password' => 'test',
+          'ApiToken' => 'Same token'
+        ))->write();
+
+        if($memberID){
+          $writtenCount++;
+        }
+      } catch(Exception $e){
+        // catch exception to not raise errors
+      }
+    }
+
+
+    $this->assertEquals(
+      1,
+      $writtenCount,
+      'The API token must be unique'
+    );
+  }
 }


### PR DESCRIPTION
Centralized code that performs token updates (removed duplicate code).
Implemented a test to assert token uniqueness.

See Issue #39 