### PR TITLE
Implemented `canLogIn` check for `authenticate` method. FIXES #52

### DIFF
--- a/code/authenticator/RESTfulAPI_TokenAuthenticator.php
+++ b/code/authenticator/RESTfulAPI_TokenAuthenticator.php
@@ -452,6 +452,10 @@ class RESTfulAPI_TokenAuthenticator implements RESTfulAPI_Authenticator
         //all good, log Member in
         if ( is_a($tokenOwner, 'Member') )
         {
+          $loginCheck = $tokenOwner->canLogIn();
+          if(!$loginCheck->valid()){
+            return new RESTfulAPI_Error(403, $loginCheck->message());
+          }
           $tokenOwner->logIn();
         }
 


### PR DESCRIPTION
The `login` method itself already checks `canLogIn`, deeply covered in `MemberAuthenticator::authenticate`, so only `authenticate` had to be fixed.

Added a test to `RESTfulAPI_TokenAuthenticator_Test` that checks both authentication methods (`login` & `authenticate`) for `canLogIn`.
