### PR TITLE
Addressing Issue #50.

### DIFF
--- a/code/serializers/Basic/RESTfulAPI_BasicSerializer.php
+++ b/code/serializers/Basic/RESTfulAPI_BasicSerializer.php
@@ -205,29 +205,26 @@ class RESTfulAPI_BasicSerializer implements RESTfulAPI_Serializer
     	//get the DataList for this realtion's name
       $dataList = $dataObject->{$relationName}();
 
-      //if there actually are objects in the relation
-      if ( $dataList->count() )
+      // check if this relation should be embedded
+      if ( $this->isEmbeddable($dataObject->ClassName, $relationName) )
       {
-      	// check if this relation should be embedded
-      	if ( $this->isEmbeddable($dataObject->ClassName, $relationName) )
-	      {
-	      	// get the relation's record(s) ready to embed
-	      	$embedData = $this->getEmbedData($dataObject, $relationName);
-	      	// embed the data if any
-	      	if ( $embedData !== null )
-	      	{
-	      		$serializedColumnName = $this->serializeColumnName( $relationName );
-	      		$formattedDataObjectMap[$serializedColumnName] = $embedData;
-	      	}
-	      }
-	      else{
-	      	// set column value to ID list
-	        $idList = $dataList->map('ID', 'ID')->keys();
-
-	        $serializedColumnName = $this->serializeColumnName( $relationName );
-	        $formattedDataObjectMap[$serializedColumnName] = $idList;
-	      }
+        // get the relation's record(s) ready to embed
+        $embedData = $this->getEmbedData($dataObject, $relationName);
+        // embed the data if any
+        if ( $embedData !== null )
+        {
+          $serializedColumnName = $this->serializeColumnName( $relationName );
+          $formattedDataObjectMap[$serializedColumnName] = $embedData;
+        }
       }
+      else{
+        // set column value to ID list
+        $idList = $dataList->map('ID', 'ID')->keys();
+
+        $serializedColumnName = $this->serializeColumnName( $relationName );
+        $formattedDataObjectMap[$serializedColumnName] = $idList;
+      }
+
     }
 
     if ( $many_many_extraFields )

--- a/tests/serializers/Basic/RESTfulAPI_BasicSerializer_Test.php
+++ b/tests/serializers/Basic/RESTfulAPI_BasicSerializer_Test.php
@@ -18,6 +18,16 @@ class RESTfulAPI_BasicSerializer_Test extends RESTfulAPI_Tester
     'ApiTest_Library'
   );
 
+  function generateDBEntries()
+  {
+    parent::generateDBEntries();
+    // create an empty library to test empty relations
+    $london = ApiTest_Library::create(array(
+      'Name' => 'London'
+    ));
+    $london->write();
+  }
+
   protected function getSerializer()
   {
     $injector   = new Injector();
@@ -89,6 +99,14 @@ class RESTfulAPI_BasicSerializer_Test extends RESTfulAPI_Tester
       is_array($jsonArray),
       "Basic Serialize dataObject should return an object"
     );
+
+    // test empty relation serialization
+    $dataObject = ApiTest_Library::get()->filter(array('Name' => 'London'))->first();
+    $result = json_decode($serializer->serialize($dataObject));
+    $this->assertTrue(
+      isset($result->Books) && is_array($result->Books),
+      "Basic Serializer should return an empty array if there are no records present"
+    );
   }
 
 
@@ -124,6 +142,13 @@ class RESTfulAPI_BasicSerializer_Test extends RESTfulAPI_Tester
     $this->assertTrue(
       is_numeric($result->Books[0]->ID),
       "Basic Serialize should return a full record for embedded records"
+    );
+
+    $dataObject = ApiTest_Library::get()->filter(array('Name' => 'London'))->first();
+    $result = json_decode($serializer->serialize($dataObject));
+    $this->assertTrue(
+      isset($result->Books) && is_array($result->Books),
+      "Basic Serializer should return an empty array if there are no records present"
     );
   }
 


### PR DESCRIPTION
Relations with no records should still show up in the serialized data, just as an empty array.
Added tests to check serialization behavior.

Looks like a big change, but most changes are due to indentation issues (there were tabs and spaces mixed, which could probably be unified across all files).