### PR TITLE
do not record login event for every tokenAuth

### DIFF
--- a/code/authenticator/RESTfulAPI_TokenAuthenticator.php
+++ b/code/authenticator/RESTfulAPI_TokenAuthenticator.php
@@ -421,7 +421,10 @@ class RESTfulAPI_TokenAuthenticator implements RESTfulAPI_Authenticator
         }
         //all good, log Member in
         if (is_a($tokenOwner, 'Member')) {
-            $tokenOwner->logIn();
+            # $tokenOwner->logIn();
+            # this is a login without the logging
+            $tokenOwner::session_regenerate_id();
+            Session::set("loggedInAs", $tokenOwner->ID);
         }
 
               return true;


### PR DESCRIPTION
doing a full login is an expensive process in silverstripe ... so if we go for token auth,
let's have some performance benefit as well .. for single record ops this can give us 300% more performance.