### PR TITLE
properly handle SiteTree objects

### DIFF
--- a/code/queryHandlers/RESTfulAPI_DefaultQueryHandler.php
+++ b/code/queryHandlers/RESTfulAPI_DefaultQueryHandler.php
@@ -427,7 +427,13 @@ class RESTfulAPI_DefaultQueryHandler implements RESTfulAPI_QueryHandler
 
           if ($hasChanges || !$model->ID) {
               try {
-                  $id = $model->write(false, false, false, $hasRelationChanges);
+                  if (is_a($model,'SiteTree')){
+                      $id = $model->writeToStage('Stage');
+                      $model->publish('Stage', 'Live');
+                  }
+                  else {
+                      $id = $model->write(false, false, false, $hasRelationChanges);
+                  }
               } catch (ValidationException $exception) {
                   $error = $exception->getResult();
                   return new RESTfulAPI_Error(400,


### PR DESCRIPTION
when changing a page, we have to use writeToStage and publish ... when using just 'write' the page will get a modified label in the cms, but the changes will not be visible ... 

what might be interesting, is to provide an argument for PUT/POST to decide if the record should be published or just staged.