### PR TITLE
Added fix for Uncaught TypeError

### DIFF
--- a/src/RESTfulAPI.php
+++ b/src/RESTfulAPI.php
@@ -445,6 +445,10 @@ class RESTfulAPI extends Controller
         } else {
             $allowedHeaders = $cors['Allow-Headers'];
         }
+
+        if (is_null($allowedHeaders))
+            $allowedHeaders = "";
+
         $answer->addHeader('Access-Control-Allow-Headers', $allowedHeaders);
 
         //allowed method


### PR DESCRIPTION
Added this fix to solve:

Argument 1 passed to SilverStripe\Control\HTTPResponse::sanitiseHeader() must be of the type string, null given.

At line 448 in RESTfulAPI.php